### PR TITLE
Breaking: drop Node.js 4 support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
     "@egy186/eslint-config/node"
   ],
   "rules": {
-    "prefer-destructuring": "off",
     "sort-keys": "off"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
 - node
 - lts/carbon
 - lts/boron
-- lts/argon
 sudo: false
 env:
   global:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4454,7 +4454,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "file-type": "^7.2.0",
     "jpeg-js": "^0.3.3",
     "pngjs": "^3.3.0",
-    "safe-buffer": "^5.1.1",
     "to-data-view": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rollup-plugin-uglify": "^3.0.0"
   },
   "engines": {
-    "node": ">=4.2.3"
+    "node": ">=6.14.0"
   },
   "files": [
     "dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,9 +6,9 @@ const jsonfile = require('jsonfile');
 const resolve = require('rollup-plugin-node-resolve');
 const uglify = require('rollup-plugin-uglify');
 
-const pkg = jsonfile.readFileSync('./package.json');
+const { version } = jsonfile.readFileSync('./package.json');
 const banner = `/*!
- * icojs v${pkg.version}
+ * icojs v${version}
  * (c) egy186
  * https://github.com/egy186/icojs/blob/master/LICENSE
  */`;

--- a/src/browser/image.js
+++ b/src/browser/image.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { MIME_PNG } = require('../mime');
+
 const dataURLToArrayBuffer = dataURL => {
   const string = atob(dataURL.replace(/.+,/, ''));
   const view = new Uint8Array(string.length);
@@ -22,18 +24,17 @@ const Image = {
       const img = document.createElement('img');
       img.src = url;
       img.onload = () => {
-        const width = img.naturalWidth;
-        const height = img.naturalHeight;
+        const { naturalHeight: height, naturalWidth: width } = img;
         const canvas = document.createElement('canvas');
         canvas.width = width;
         canvas.height = height;
         const ctx = canvas.getContext('2d');
         ctx.drawImage(img, 0, 0);
-        const imageData = ctx.getImageData(0, 0, width, height);
+        const { data } = ctx.getImageData(0, 0, width, height);
         resolve({
-          width: imageData.width,
-          height: imageData.height,
-          data: imageData.data
+          data,
+          height,
+          width
         });
       };
     });
@@ -48,20 +49,20 @@ const Image = {
    * @param {String} [mime=image/png] MIME type
    * @returns {ArrayBuffer} image
    */
-  encode (image, mime) {
+  encode (image, mime = MIME_PNG) {
     return new Promise(resolve => {
-      const data = image.data;
+      const { data, height, width } = image;
       const canvas = document.createElement('canvas');
-      canvas.width = image.width;
-      canvas.height = image.height;
+      canvas.width = width;
+      canvas.height = height;
       const ctx = canvas.getContext('2d');
-      const imageData = ctx.createImageData(image.width, image.height);
+      const imageData = ctx.createImageData(width, height);
       const dataData = imageData.data;
       for (let i = 0; i < dataData.length; i++) {
         dataData[i] = data[i];
       }
       ctx.putImageData(imageData, 0, 0);
-      resolve(dataURLToArrayBuffer(canvas.toDataURL(mime || 'image/png')));
+      resolve(dataURLToArrayBuffer(canvas.toDataURL(mime)));
     });
   }
 };

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -3,6 +3,7 @@
 const Image = require('./image');
 const isICO = require('../is-ico');
 const parseICO = require('../parse');
+const { MIME_PNG } = require('../mime');
 
 const globalICO = global.ICO;
 
@@ -13,7 +14,7 @@ const globalICO = global.ICO;
  * @param {String} [mime=image/png] MIME type for output.
  * @returns {Promise<ParsedImage[]>} Resolves to an array of {@link ParsedImage}.
  */
-const parse = (arrayBuffer, mime) => parseICO(arrayBuffer, mime || 'image/png', Image);
+const parse = (arrayBuffer, mime = MIME_PNG) => parseICO(arrayBuffer, mime, Image);
 
 /**
  * @class ICO

--- a/src/mime.js
+++ b/src/mime.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const MIME_BMP = 'image/bmp';
+const MIME_JPEG = 'image/jpeg';
+const MIME_PNG = 'image/png';
+
+module.exports = {
+  MIME_BMP,
+  MIME_JPEG,
+  MIME_PNG
+};
+

--- a/src/node/image.js
+++ b/src/node/image.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const PNG = require('pngjs').PNG;
 const bmp = require('bmp-js');
 const fileType = require('file-type');

--- a/src/node/image.js
+++ b/src/node/image.js
@@ -1,13 +1,10 @@
 'use strict';
 
-const PNG = require('pngjs').PNG;
 const bmp = require('bmp-js');
 const fileType = require('file-type');
 const jpeg = require('jpeg-js');
-
-const MIME_BMP = 'image/bmp';
-const MIME_JPEG = 'image/jpeg';
-const MIME_PNG = 'image/png';
+const { MIME_BMP, MIME_JPEG, MIME_PNG } = require('../mime');
+const { PNG } = require('pngjs');
 
 const decoders = {
   [MIME_BMP]: bmp.decode,
@@ -45,17 +42,16 @@ const Image = {
    */
   decodeSync (arrayBuffer) {
     const buffer = Buffer.from(arrayBuffer);
-    const type = fileType(buffer);
-    const mime = type ? type.mime : null;
+    const { mime } = fileType(buffer) || {};
     if (!(mime in decoders)) {
       throw new TypeError(`${mime} is not supported`);
     }
     const decoder = decoders[mime];
-    const imageData = decoder(buffer);
+    const { data, height, width } = decoder(buffer);
     return {
-      data: new Uint8ClampedArray(imageData.data),
-      height: imageData.height,
-      width: imageData.width
+      data: new Uint8ClampedArray(data),
+      height,
+      width
     };
   },
   /**
@@ -87,7 +83,7 @@ const Image = {
    * @param {String} [mime=image/png] MIME type
    * @returns {ArrayBuffer} image
    */
-  encodeSync (image, mime) {
+  encodeSync (image, mime = MIME_PNG) {
     const imageData = {
       data: Buffer.from(image.data),
       height: image.height,

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -4,6 +4,7 @@ const Image = require('./image');
 const arrayBufferIsICO = require('../is-ico');
 const parseICO = require('../parse');
 const parseICOSync = require('../parse/sync');
+const { MIME_PNG } = require('../mime');
 
 /**
  * Check the ArrayBuffer is valid ICO.
@@ -20,7 +21,7 @@ const isICO = buffer => arrayBufferIsICO(buffer);
  * @param {String} [mime=image/png] MIME type for output.
  * @returns {Promise<ParsedImage[]>} Resolves to an array of {@link ParsedImage}.
  */
-const parse = (buffer, mime) => parseICO(buffer, mime || 'image/png', Image);
+const parse = (buffer, mime = MIME_PNG) => parseICO(buffer, mime, Image);
 
 /**
  * Parse ICO and return some images synchronously.
@@ -29,7 +30,7 @@ const parse = (buffer, mime) => parseICO(buffer, mime || 'image/png', Image);
  * @param {String} [mime=image/png] MIME type for output.
  * @returns {ParsedImage[]} Returns an array of {@link ParsedImage}.
  */
-const parseSync = (buffer, mime) => parseICOSync(buffer, mime || 'image/png', Image);
+const parseSync = (buffer, mime = MIME_PNG) => parseICOSync(buffer, mime, Image);
 
 /**
  * @module ICO

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const decodeIco = require('decode-ico');
+const { MIME_PNG } = require('../mime');
 
 /**
  * @typedef {Object} ParsedImage
@@ -44,7 +45,7 @@ const parse = (data, mime, Image) => {
   }));
 
   const transcodeImage = icon => {
-    if (mime === 'image/png' && icon.type === 'png') {
+    if (mime === MIME_PNG && icon.type === 'png') {
       return Promise.resolve(Object.assign({ buffer: icon.data.buffer.slice(icon.data.byteOffset, icon.data.byteOffset + icon.data.byteLength) }, icon));
     }
     return decodePng(icon).then(encodeImage);

--- a/src/parse/sync.js
+++ b/src/parse/sync.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const decodeIco = require('decode-ico');
+const { MIME_PNG } = require('../mime');
 
 /**
  * Parse ICO and return some image object.
@@ -14,7 +15,7 @@ const parseSync = (data, mime, Image) => {
   const icons = decodeIco(data);
 
   const transcodeImage = icon => {
-    if (mime === 'image/png' && icon.type === 'png') {
+    if (mime === MIME_PNG && icon.type === 'png') {
       return Object.assign({ buffer: icon.data.buffer.slice(icon.data.byteOffset, icon.data.byteOffset + icon.data.byteLength) }, icon);
     }
 

--- a/test/fixtures/images/basic.js
+++ b/test/fixtures/images/basic.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
-
 const split = colors => colors.split('|').map(color => color.split(',').map(s => parseInt(s, 10)));
 
 const basic = [

--- a/test/is-cur.spec.js
+++ b/test/is-cur.spec.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const chai = require('chai');
+const { expect } = require('chai');
 const fs = require('fs');
 const isCUR = require('../src/is-cur');
 const path = require('path');
-
-const expect = chai.expect;
 
 describe('isCUR', () => {
   it('is expected to return true or false', () => {

--- a/test/is-ico.spec.js
+++ b/test/is-ico.spec.js
@@ -1,14 +1,9 @@
 'use strict';
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+const { expect } = require('chai');
 const fs = require('fs');
 const isICO = require('../src/is-ico');
 const path = require('path');
-
-chai.use(chaiAsPromised);
-
-const expect = chai.expect;
 
 describe('isICO', () => {
   it('is expected to return true or false', () => {

--- a/test/is-png.spec.js
+++ b/test/is-png.spec.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const chai = require('chai');
+const { expect } = require('chai');
 const fs = require('fs');
 const isPNG = require('../src/is-png');
 const path = require('path');
-
-const expect = chai.expect;
 
 describe('isPNG', () => {
   it('is expected to return true or false', () => {

--- a/test/node/image.spec.js
+++ b/test/node/image.spec.js
@@ -1,13 +1,11 @@
 'use strict';
 
 const Image = require('../../src/node/image');
-const chai = require('chai');
+const { expect } = require('chai');
 const fileType = require('file-type');
 const fs = require('fs');
 const isSame = require('../fixtures/is-same');
 const path = require('path');
-
-const expect = chai.expect;
 
 describe('Image', () => {
   describe('.decodeSync', () => {

--- a/test/node/index.spec.js
+++ b/test/node/index.spec.js
@@ -1,16 +1,14 @@
 'use strict';
 
 const ICO = require('../../src/node');
-const chai = require('chai');
+const { expect, use } = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const cursorCur = require('../fixtures/images/cursor');
 const fs = require('fs');
 const isSame = require('../fixtures/is-same');
 const path = require('path');
 
-chai.use(chaiAsPromised);
-
-const expect = chai.expect;
+use(chaiAsPromised);
 
 describe('ICO', () => {
   describe('.isICO', () => {


### PR DESCRIPTION
Closes #84.

- [x] Remove `safe-buffer` from dependency
- [x] Use es2015 features like default function parameters, rest parameters, spread operator...