### PR TITLE
Docs: simplify API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,20 @@ ICO.parse(buffer, 'image/png').then(images => {
 
 [https://egy186.github.io/icojs/#demo](https://egy186.github.io/icojs/#demo)
 
-## API (Node.js)
+## API
 
 <a name="module_ICO"></a>
 
 ### ICO
 
 * [ICO](#module_ICO)
-    * [isICO(buffer)](#exp_module_ICO--isICO) ⇒ <code>Boolean</code> ⏏
+    * [isICO(source)](#exp_module_ICO--isICO) ⇒ <code>Boolean</code> ⏏
     * [parse(buffer, [mime])](#exp_module_ICO--parse) ⇒ <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code> ⏏
     * [parseSync(buffer, [mime])](#exp_module_ICO--parseSync) ⇒ [<code>Array.&lt;ParsedImage&gt;</code>](#ParsedImage) ⏏
 
 <a name="exp_module_ICO--isICO"></a>
 
-#### isICO(buffer) ⇒ <code>Boolean</code> ⏏
+#### isICO(source) ⇒ <code>Boolean</code> ⏏
 Check the ArrayBuffer is valid ICO.
 
 **Kind**: global method of [<code>ICO</code>](#module_ICO)  
@@ -99,7 +99,7 @@ Check the ArrayBuffer is valid ICO.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| buffer | <code>ArrayBuffer</code> \| <code>Buffer</code> | ICO file data. |
+| source | <code>ArrayBuffer</code> \| <code>Buffer</code> | ICO file data. |
 
 <a name="exp_module_ICO--parse"></a>
 
@@ -117,7 +117,7 @@ Parse ICO and return some images.
 <a name="exp_module_ICO--parseSync"></a>
 
 #### parseSync(buffer, [mime]) ⇒ [<code>Array.&lt;ParsedImage&gt;</code>](#ParsedImage) ⏏
-Parse ICO and return some images synchronously.
+Parse ICO and return some images synchronously **(Node.js only)**.
 
 **Kind**: global method of [<code>ICO</code>](#module_ICO)  
 **Returns**: [<code>Array.&lt;ParsedImage&gt;</code>](#ParsedImage) - Returns an array of [ParsedImage](#ParsedImage).  
@@ -126,51 +126,6 @@ Parse ICO and return some images synchronously.
 | --- | --- | --- | --- |
 | buffer | <code>ArrayBuffer</code> \| <code>Buffer</code> |  | ICO file data. |
 | [mime] | <code>String</code> | <code>image/png</code> | MIME type for output. |
-
-
-## API (browser)
-
-<a name="ICO"></a>
-
-### ICO
-**Kind**: global class  
-
-* [ICO](#ICO)
-    * [.parse(arrayBuffer, [mime])](#ICO.parse) ⇒ <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code>
-    * [.noConflict()](#ICO.noConflict) ⇒ [<code>ICO</code>](#ICO)
-    * [.isICO(source)](#ICO.isICO) ⇒ <code>Boolean</code>
-
-<a name="ICO.parse"></a>
-
-#### ICO.parse(arrayBuffer, [mime]) ⇒ <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code>
-Parse ICO and return some images.
-
-**Kind**: static method of [<code>ICO</code>](#ICO)  
-**Returns**: <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code> - Resolves to an array of [ParsedImage](#ParsedImage).  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| arrayBuffer | <code>ArrayBuffer</code> |  | ICO file data. |
-| [mime] | <code>String</code> | <code>image/png</code> | MIME type for output. |
-
-<a name="ICO.noConflict"></a>
-
-#### ICO.noConflict() ⇒ [<code>ICO</code>](#ICO)
-No conflict.
-
-**Kind**: static method of [<code>ICO</code>](#ICO)  
-**Returns**: [<code>ICO</code>](#ICO) - `ICO` Object.  
-<a name="ICO.isICO"></a>
-
-#### ICO.isICO(source) ⇒ <code>Boolean</code>
-Check the ArrayBuffer is valid ICO.
-
-**Kind**: static method of [<code>ICO</code>](#ICO)  
-**Returns**: <code>Boolean</code> - True if arg is ICO.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| source | <code>ArrayBuffer</code> \| <code>Buffer</code> | ICO file data. |
 
 
 ## Typedefs

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,20 +44,20 @@ ICO.parse(buffer, 'image/png').then(images =&gt; {
   }, false);
 &lt;/script&gt;
 </code></pre>
-</section><section id="demo"><h2>Demo</h2><p>Please input ico file.</p><form action="#"><p class="input-group"><span class="input-group-prepend"><button class="btn btn-outline-primary" id="input-file-emu">Choose file</button></span><span class="custom-file"><input class="custom-file-input" id="input-file" type="file"><label class="custom-file-label" id="input-file-path" for="input-file"></label></span></p></form><section id="demos-parse-results"></section></section><section id="api"><h2>API (Node.js)</h2>
+</section><section id="demo"><h2>Demo</h2><p>Please input ico file.</p><form action="#"><p class="input-group"><span class="input-group-prepend"><button class="btn btn-outline-primary" id="input-file-emu">Choose file</button></span><span class="custom-file"><input class="custom-file-input" id="input-file" type="file"><label class="custom-file-label" id="input-file-path" for="input-file"></label></span></p></form><section id="demos-parse-results"></section></section><section id="api"><h2>API</h2>
 <p><a name="module_ICO"></a></p>
 <h3>ICO</h3>
 <ul>
 <li><a href="#module_ICO">ICO</a>
 <ul>
-<li><a href="#exp_module_ICO--isICO">isICO(buffer)</a> ⇒ <code>Boolean</code> ⏏</li>
+<li><a href="#exp_module_ICO--isICO">isICO(source)</a> ⇒ <code>Boolean</code> ⏏</li>
 <li><a href="#exp_module_ICO--parse">parse(buffer, [mime])</a> ⇒ <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code> ⏏</li>
 <li><a href="#exp_module_ICO--parseSync">parseSync(buffer, [mime])</a> ⇒ <a href="#ParsedImage"><code>Array.&lt;ParsedImage&gt;</code></a> ⏏</li>
 </ul>
 </li>
 </ul>
 <p><a name="exp_module_ICO--isICO"></a></p>
-<h4>isICO(buffer) ⇒ <code>Boolean</code> ⏏</h4>
+<h4>isICO(source) ⇒ <code>Boolean</code> ⏏</h4>
 <p>Check the ArrayBuffer is valid ICO.</p>
 <p><strong>Kind</strong>: global method of <a href="#module_ICO"><code>ICO</code></a><br>
 <strong>Returns</strong>: <code>Boolean</code> - True if arg is ICO.</p>
@@ -71,7 +71,7 @@ ICO.parse(buffer, 'image/png').then(images =&gt; {
 </thead>
 <tbody>
 <tr>
-<td>buffer</td>
+<td>source</td>
 <td><code>ArrayBuffer</code> | <code>Buffer</code></td>
 <td>ICO file data.</td>
 </tr>
@@ -108,7 +108,7 @@ ICO.parse(buffer, 'image/png').then(images =&gt; {
 </table>
 <p><a name="exp_module_ICO--parseSync"></a></p>
 <h4>parseSync(buffer, [mime]) ⇒ <a href="#ParsedImage"><code>Array.&lt;ParsedImage&gt;</code></a> ⏏</h4>
-<p>Parse ICO and return some images synchronously.</p>
+<p>Parse ICO and return some images synchronously <strong>(Node.js only)</strong>.</p>
 <p><strong>Kind</strong>: global method of <a href="#module_ICO"><code>ICO</code></a><br>
 <strong>Returns</strong>: <a href="#ParsedImage"><code>Array.&lt;ParsedImage&gt;</code></a> - Returns an array of <a href="#ParsedImage">ParsedImage</a>.</p>
 <table>
@@ -132,74 +132,6 @@ ICO.parse(buffer, 'image/png').then(images =&gt; {
 <td><code>String</code></td>
 <td><code>image/png</code></td>
 <td>MIME type for output.</td>
-</tr>
-</tbody>
-</table>
-<h2>API (browser)</h2>
-<p><a name="ICO"></a></p>
-<h3>ICO</h3>
-<p><strong>Kind</strong>: global class</p>
-<ul>
-<li><a href="#ICO">ICO</a>
-<ul>
-<li><a href="#ICO.parse">.parse(arrayBuffer, [mime])</a> ⇒ <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code></li>
-<li><a href="#ICO.noConflict">.noConflict()</a> ⇒ <a href="#ICO"><code>ICO</code></a></li>
-<li><a href="#ICO.isICO">.isICO(source)</a> ⇒ <code>Boolean</code></li>
-</ul>
-</li>
-</ul>
-<p><a name="ICO.parse"></a></p>
-<h4>ICO.parse(arrayBuffer, [mime]) ⇒ <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code></h4>
-<p>Parse ICO and return some images.</p>
-<p><strong>Kind</strong>: static method of <a href="#ICO"><code>ICO</code></a><br>
-<strong>Returns</strong>: <code>Promise.&lt;Array.&lt;ParsedImage&gt;&gt;</code> - Resolves to an array of <a href="#ParsedImage">ParsedImage</a>.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>arrayBuffer</td>
-<td><code>ArrayBuffer</code></td>
-<td></td>
-<td>ICO file data.</td>
-</tr>
-<tr>
-<td>[mime]</td>
-<td><code>String</code></td>
-<td><code>image/png</code></td>
-<td>MIME type for output.</td>
-</tr>
-</tbody>
-</table>
-<p><a name="ICO.noConflict"></a></p>
-<h4>ICO.noConflict() ⇒ <a href="#ICO"><code>ICO</code></a></h4>
-<p>No conflict.</p>
-<p><strong>Kind</strong>: static method of <a href="#ICO"><code>ICO</code></a><br>
-<strong>Returns</strong>: <a href="#ICO"><code>ICO</code></a> - <code>ICO</code> Object.<br>
-<a name="ICO.isICO"></a></p>
-<h4>ICO.isICO(source) ⇒ <code>Boolean</code></h4>
-<p>Check the ArrayBuffer is valid ICO.</p>
-<p><strong>Kind</strong>: static method of <a href="#ICO"><code>ICO</code></a><br>
-<strong>Returns</strong>: <code>Boolean</code> - True if arg is ICO.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>source</td>
-<td><code>ArrayBuffer</code> | <code>Buffer</code></td>
-<td>ICO file data.</td>
 </tr>
 </tbody>
 </table>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ const config = {
     file: 'dist/ico.js',
     format: 'umd',
     name: 'ICO',
+    noConflict: true,
     sourcemap: true
   },
   plugins: [

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -4,31 +4,10 @@ const Image = require('./image');
 const isICO = require('../is-ico');
 const parseICO = require('../parse');
 
-const globalICO = global.ICO;
-
-/**
- * Parse ICO and return some images.
- * @memberof ICO
- * @param {ArrayBuffer} arrayBuffer ICO file data.
- * @param {String} [mime=image/png] MIME type for output.
- * @returns {Promise<ParsedImage[]>} Resolves to an array of {@link ParsedImage}.
- */
 const parse = (arrayBuffer, mime) => parseICO(arrayBuffer, mime || 'image/png', Image);
 
-/**
- * @class ICO
- */
 const ICO = {
   isICO,
-  /**
-   * No conflict.
-   * @memberof ICO
-   * @returns {ICO} `ICO` Object.
-   */
-  noConflict () {
-    global.ICO = globalICO;
-    return this;
-  },
   parse
 };
 

--- a/src/is-ico.js
+++ b/src/is-ico.js
@@ -4,7 +4,7 @@ const toDataView = require('to-data-view');
 
 /**
  * Check the ArrayBuffer is valid ICO.
- * @memberof ICO
+ * @alias module:ICO
  * @param {ArrayBuffer|Buffer} source ICO file data.
  * @returns {Boolean} True if arg is ICO.
  */

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -1,17 +1,9 @@
 'use strict';
 
 const Image = require('./image');
-const arrayBufferIsICO = require('../is-ico');
+const isICO = require('../is-ico');
 const parseICO = require('../parse');
 const parseICOSync = require('../parse/sync');
-
-/**
- * Check the ArrayBuffer is valid ICO.
- * @alias module:ICO
- * @param {ArrayBuffer|Buffer} buffer ICO file data.
- * @returns {Boolean} True if arg is ICO.
- */
-const isICO = buffer => arrayBufferIsICO(buffer);
 
 /**
  * Parse ICO and return some images.
@@ -23,7 +15,7 @@ const isICO = buffer => arrayBufferIsICO(buffer);
 const parse = (buffer, mime) => parseICO(buffer, mime || 'image/png', Image);
 
 /**
- * Parse ICO and return some images synchronously.
+ * Parse ICO and return some images synchronously **(Node.js only)**.
  * @alias module:ICO
  * @param {ArrayBuffer|Buffer} buffer ICO file data.
  * @param {String} [mime=image/png] MIME type for output.

--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -1,14 +1,8 @@
-## API (Node.js)
+## API
 
 {{#module name="ICO"}}
 {{>docs}}
 {{/module}}
-
-## API (browser)
-
-{{#class name="ICO"}}
-{{>docs}}
-{{/class}}
 
 ## Typedefs
 


### PR DESCRIPTION
The browserify bundle can accept `Buffer` thanks to `to-data-view`, but doesn't have `ICO.parseSync()`.