### PR TITLE
build: fixes "Default condition should be last one" on Node 20 and Next.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
   },
   "exports": {
     ".": {
-      "default": "./src/node/index.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./src/node/index.js"
     },
     "./browser": {
-      "default": "./src/browser/index.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./src/browser/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Updates the default export to be the last key in the array.

Specifically, when running this module in a Next.js environment on Node 20, I can't import the module at all.

```bash
Module not found: Default condition should be last one
  2 | import sharp from 'sharp';
  3 |
> 4 | import icojs from 'icojs'
```

It looks like other packages also run into this problem, and I found the fix through this comment:

https://github.com/mpociot/chatgpt-vscode/issues/1#issuecomment-1337384976

A similar issue is mentioned here:

https://stackoverflow.com/questions/76127288/module-not-found-error-default-condition-should-be-last-one