### PR TITLE
chore: rename parseICO and isICO to use camelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install icojs
 ```
 
 ```js
-import { isICO, parseICO } from 'icojs';
+import { decodeIco, isIco } from 'icojs';
 ```
 
 A UMD bundle is also available for browsers.
@@ -29,10 +29,10 @@ A UMD bundle is also available for browsers.
 
 ```js
 import { readFile, writeFile } from 'node:fs/promises';
-import { parseICO } from 'icojs';
+import { decodeIco } from 'icojs';
 
 const buffer = await readFile('favicon.ico');
-const images = await parseICO(buffer, 'image/png');
+const images = await decodeIco(buffer, 'image/png');
 // save as png files
 images.forEach(image => {
   const file = `${image.width}x${image.height}-${image.bpp}bit.png`;
@@ -49,7 +49,7 @@ images.forEach(image => {
   document.querySelector('#input-file').addEventListener('change', async evt => {
     const file = evt.target.files[0];
     const buffer = await file.arrayBuffer();
-    const images = await ICO.parseICO(buffer);
+    const images = await ICO.decodeIco(buffer);
     // logs images
     console.dir(images);
   });

--- a/assets/demo.html
+++ b/assets/demo.html
@@ -29,7 +29,7 @@
   <form action="#">
     <p><input id="input-file" type="file" multiple class="form-control" aria-label="Choose file" /></p>
   </form>
-  <section id="demos-parse-results"></section>
+  <section id="demo-decode-results"></section>
 </body>
 
 </html>

--- a/assets/demo.js
+++ b/assets/demo.js
@@ -3,7 +3,7 @@ $(() => {
   const mime = 'image/png';
 
   // Handler
-  const parseComplete = (err, images) => {
+  const decodeComplete = (err, images) => {
     const alert = $('<div class="alert alert-dismissible fade show">');
     alert.append('<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>');
     if (err) {
@@ -18,20 +18,20 @@ $(() => {
         alert.append(`<p class="mb-${index === images.length - 1 ? 0 : 3}"><a href="${url}" target="_blank"><img src="${url}" /> ${text}</a></p>`);
       });
     }
-    alert.prependTo('#demos-parse-results');
+    alert.prependTo('#demo-decode-results');
   };
 
-  const icoParse = async files => {
+  const icoDecode = async files => {
     for (const file of files) {
       try {
         const buffer = await file.arrayBuffer();
         // Convert *.ico to *.png(s)
-        const images = await ICO.parseICO(buffer, mime);
+        const images = await ICO.decodeIco(buffer, mime);
         // Debug
         console.dir(images);
-        parseComplete(null, images);
+        decodeComplete(null, images);
       } catch (err) {
-        parseComplete(err);
+        decodeComplete(err);
       }
     }
   };
@@ -48,12 +48,12 @@ $(() => {
   $(document).on('drop', evt => {
     evt.stopPropagation();
     evt.preventDefault();
-    icoParse(evt.originalEvent.dataTransfer.files);
+    icoDecode(evt.originalEvent.dataTransfer.files);
   });
 
   // Input from file
   $('#input-file').on('change', evt => {
-    icoParse(evt.target.files);
+    icoDecode(evt.target.files);
   });
 
   // Set theme

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "icojs",
   "version": "0.21.1",
-  "description": "parse ico file",
+  "description": "decode ico file",
   "keywords": [
     "ico",
-    "parse"
+    "decode"
   ],
   "homepage": "https://egy186.github.io/icojs",
   "bugs": {

--- a/src/browser/index.test.ts
+++ b/src/browser/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import Bowser from 'bowser';
+import { decodeIco } from './index.js';
 import { isSame } from '../test-fixtures/is-same-browser.js';
-import { parseICO } from './index.js';
 
 const browserName = Bowser.getParser(window.navigator.userAgent).getBrowserName();
 
-describe('ICO.parseICO in the browser', () => {
+describe('ICO.decodeIco in the browser', () => {
   const icons = [
     'basic.ico',
     'cursor.cur',
@@ -13,11 +13,11 @@ describe('ICO.parseICO in the browser', () => {
     'png.ico'
   ];
   icons.forEach(icon => {
-    it(`parse ${icon}`, async () => {
+    it(`decode ${icon}`, async () => {
       const res = await fetch(`/src/test-fixtures/images/${icon}`);
       const arrayBuffer = await res.arrayBuffer();
 
-      const images = await parseICO(arrayBuffer);
+      const images = await decodeIco(arrayBuffer);
       expect(images.length).toBeGreaterThan(0);
 
       // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types, max-statements

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,18 +1,31 @@
+import type { DecodeImage } from '../decode.js';
 import Image from './image.js';
-import type { ParsedImage } from '../parse.js';
-import { isICO } from '../is-ico.js';
-import { parse } from '../parse.js';
+import { decode } from '../decode.js';
+import { isIco } from '../is-ico.js';
 
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const parseICO = async (arrayBuffer: ArrayBuffer, mime = 'image/png'): Promise<Array<ParsedImage>> => await parse(arrayBuffer, mime, Image);
+const decodeIco = async (arrayBuffer: ArrayBuffer, mime = 'image/png'): Promise<Array<DecodeImage>> => await decode(arrayBuffer, mime, Image);
+
+/** @deprecated Use `isIco` instead. */
+const isICO = isIco;
+
+// eslint-disable-next-line jsdoc/require-param, jsdoc/require-returns
+/** @deprecated Use `decodeIco` instead. */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+const parseICO = async (arrayBuffer: ArrayBuffer, mime = 'image/png'): Promise<Array<DecodeImage>> => await decode(arrayBuffer, mime, Image);
 
 const ICO = {
+  decodeIco,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   isICO,
+  isIco,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   parseICO
 };
 
-export type { ParsedImage };
+export type { DecodeImage };
 
-export { isICO, parseICO };
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export { decodeIco, isICO, isIco, parseICO };
 
 export default ICO;

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -4,7 +4,7 @@ import decodeIco from 'decode-ico';
 
 // eslint-disable-next-line jsdoc/no-blank-blocks
 /** */
-interface ParsedImage {
+interface DecodeImage {
   /** Image width. */
   readonly width: number;
   /** Image height. */
@@ -29,20 +29,20 @@ interface IconData {
 }
 
 /**
- * Parse ICO and return some image object.
+ * Decode ICO and return some image object.
  *
  * @param data - ICO file data.
  * @param mime - MIME type for output.
  * @param Image - Image encoder/decoder.
- * @returns Resolves to an array of {@link ParsedImage}.
+ * @returns Resolves to an array of {@link DecodeImage}.
  * @access private
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/prefer-readonly-parameter-types
-const parse = async (data: ArrayBuffer | Buffer, mime: string, Image: ImageConverter): Promise<Array<ParsedImage>> => {
+const decode = async (data: ArrayBuffer | Buffer, mime: string, Image: ImageConverter): Promise<Array<DecodeImage>> => {
   const icons = decodeIco(data);
 
   // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-  const transcodeImage = async (icon: IconData): Promise<ParsedImage> => {
+  const transcodeImage = async (icon: IconData): Promise<DecodeImage> => {
     if (mime === MIME_PNG && icon.type === 'png') {
       return {
         ...icon,
@@ -64,12 +64,12 @@ const parse = async (data: ArrayBuffer | Buffer, mime: string, Image: ImageConve
     });
   };
 
-  const parsedImages = await Promise.all(icons.map(transcodeImage));
-  return parsedImages;
+  const decodedImages = await Promise.all(icons.map(transcodeImage));
+  return decodedImages;
 };
 
-export type { ParsedImage };
+export type { DecodeImage };
 
-export { parse };
+export { decode };
 
-export default parse;
+export default decode;

--- a/src/is-cur.ts
+++ b/src/is-cur.ts
@@ -8,11 +8,11 @@ import toDataView from 'to-data-view';
  * @access private
  */
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const isCUR = (source: ArrayBuffer | Buffer): boolean => {
+const isCur = (source: ArrayBuffer | Buffer): boolean => {
   const dataView = toDataView(source);
   return dataView.getUint16(0, true) === 0 && dataView.getUint16(2, true) === 2;
 };
 
-export { isCUR };
+export { isCur };
 
-export default isCUR;
+export default isCur;

--- a/src/is-ico.ts
+++ b/src/is-ico.ts
@@ -7,11 +7,11 @@ import toDataView from 'to-data-view';
  * @returns True if arg is ICO.
  */
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const isICO = (source: ArrayBuffer | Buffer): boolean => {
+const isIco = (source: ArrayBuffer | Buffer): boolean => {
   const dataView = toDataView(source);
   return dataView.getUint16(0, true) === 0 && dataView.getUint16(2, true) === 1;
 };
 
-export { isICO };
+export { isIco };
 
-export default isICO;
+export default isIco;

--- a/src/is-png.ts
+++ b/src/is-png.ts
@@ -8,11 +8,11 @@ import toDataView from 'to-data-view';
  * @access private
  */
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const isPNG = (source: ArrayBuffer | Buffer): boolean => {
+const isPng = (source: ArrayBuffer | Buffer): boolean => {
   const dataView = toDataView(source);
   return dataView.getUint32(0, false) === 0x89504E47 && dataView.getUint32(4, false) === 0x0D0A1A0A;
 };
 
-export { isPNG };
+export { isPng };
 
-export default isPNG;
+export default isPng;

--- a/src/node/image.ts
+++ b/src/node/image.ts
@@ -1,7 +1,7 @@
 import type { ImageConverter, ImageData } from '../image.js';
 import { MIME_BMP, MIME_JPEG, MIME_PNG } from '../image.js';
-import { decode as decodeBMP, encode as encodeBMP } from 'bmp-ts';
-import { decode as decodeJPEG, encode as encodeJPEG } from 'jpeg-js';
+import { decode as decodeBmp, encode as encodeBmp } from 'bmp-ts';
+import { decode as decodeJpeg, encode as encodeJpeg } from 'jpeg-js';
 import { PNG } from 'pngjs';
 import { fileTypeFromBuffer } from 'file-type';
 
@@ -62,7 +62,7 @@ interface ImageDecoders {
 const decoders = {
   /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
   [MIME_BMP]: (buffer: Buffer) => {
-    const bmpImageData = decodeBMP(buffer);
+    const bmpImageData = decodeBmp(buffer);
 
     return {
       data: abgrToRgba(bmpImageData.data),
@@ -70,7 +70,7 @@ const decoders = {
       width: bmpImageData.width
     };
   },
-  [MIME_JPEG]: (buffer: Buffer) => decodeJPEG(buffer),
+  [MIME_JPEG]: (buffer: Buffer) => decodeJpeg(buffer),
   [MIME_PNG]: (buffer: Buffer) => PNG.sync.read(buffer)
   /* eslint-enable @typescript-eslint/prefer-readonly-parameter-types */
 } as const satisfies ImageDecoders;
@@ -88,9 +88,9 @@ const encoders = {
       data: rgbaToAbgr(imageData.data)
     };
 
-    return encodeBMP(bmpImageData).data;
+    return encodeBmp(bmpImageData).data;
   },
-  [MIME_JPEG]: (imageData: ImageDataLike) => encodeJPEG(imageData).data,
+  [MIME_JPEG]: (imageData: ImageDataLike) => encodeJpeg(imageData).data,
   [MIME_PNG]: (imageData: ImageDataLike) => {
     const png = new PNG({
       height: imageData.height,

--- a/src/node/index.test.ts
+++ b/src/node/index.test.ts
@@ -1,36 +1,36 @@
+import { decodeIco, isIco } from './index.js';
 import { describe, expect, it } from 'vitest';
-import { isICO, parseICO } from './index.js';
 import cursorCur from '../test-fixtures/images/cursor.js';
 import { isSame } from '../test-fixtures/is-same.js';
 import { readFile } from 'node:fs/promises';
 
 // eslint-disable-next-line max-lines-per-function
 describe('ICO', () => {
-  describe('.isICO', () => {
+  describe('.isIco', () => {
     it('is expected to return true or false', async () => {
       const buffer = await readFile(new URL('../test-fixtures/images/basic.ico', import.meta.url));
       // @ts-expect-error test
-      expect(() => isICO('it is not buffer')).toThrow(TypeError);
-      expect(isICO(buffer)).toStrictEqual(true);
+      expect(() => isIco('it is not buffer')).toThrow(TypeError);
+      expect(isIco(buffer)).toStrictEqual(true);
       const d = new ArrayBuffer(4);
       const dv = new DataView(d);
-      expect(isICO(d)).toStrictEqual(false);
+      expect(isIco(d)).toStrictEqual(false);
       dv.setUint16(2, 1, true);
-      expect(isICO(d)).toStrictEqual(true);
+      expect(isIco(d)).toStrictEqual(true);
       dv.setUint16(0, 1, true);
-      expect(isICO(d)).toStrictEqual(false);
+      expect(isIco(d)).toStrictEqual(false);
     });
   });
 
   // eslint-disable-next-line max-lines-per-function
-  describe('.parse', () => {
+  describe('.decodeIco', () => {
     it('is expected to be rejected when arg is not buffer', async () => {
       // @ts-expect-error test
-      const promise = parseICO([]);
+      const promise = decodeIco([]);
       await expect(promise).rejects.toThrow(TypeError);
     });
     it('is expected to be rejected when arg is not ico', async () => {
-      const promise = parseICO(new ArrayBuffer(4));
+      const promise = decodeIco(new ArrayBuffer(4));
       await expect(promise).rejects.toThrow('Truncated header');
     });
     const formats = [
@@ -47,9 +47,9 @@ describe('ICO', () => {
     ];
     formats.forEach(format => {
       icons.forEach(icon => {
-        it(`is expected to parse ${icon} (${format ?? 'default'})`, async () => {
+        it(`is expected to decode ${icon} (${format ?? 'default'})`, async () => {
           const buffer = await readFile(new URL(`../test-fixtures/images/${icon}`, import.meta.url));
-          const images = await parseICO(buffer, format);
+          const images = await decodeIco(buffer, format);
           expect(Array.isArray(images)).toStrictEqual(true);
           // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
           await Promise.all(images.map(async image => {
@@ -65,9 +65,9 @@ describe('ICO', () => {
         });
       });
     });
-    it('is expected to parse hotspot of CUR', async () => {
+    it('is expected to decode hotspot of CUR', async () => {
       const buffer = await readFile(new URL('../test-fixtures/images/cursor.cur', import.meta.url));
-      const images = await parseICO(buffer);
+      const images = await decodeIco(buffer);
       // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
       images.forEach((image, index) => {
         expect(image.hotspot?.x).not.toBeUndefined();

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,25 +1,51 @@
+import type { DecodeImage } from '../decode.js';
 import Image from './image.js';
-import type { ParsedImage } from '../parse.js';
-import { isICO } from '../is-ico.js';
-import { parse } from '../parse.js';
+import { decode } from '../decode.js';
+import { deprecate } from 'node:util';
+import { isIco } from '../is-ico.js';
+
+/**
+ * Decode ICO and return some images.
+ *
+ * @param buffer - ICO file data.
+ * @param mime - MIME type for output.
+ * @returns Resolves to an array of {@link DecodeImage}.
+ */
+// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+const decodeIco = async (buffer: ArrayBuffer | Buffer, mime = 'image/png'): Promise<Array<DecodeImage>> => await decode(buffer, mime, Image);
+
+/** @deprecated Use {@link isIco} instead. */
+const isICO = deprecate(
+  isIco,
+  'isICO is deprecated. Use isIco instead.'
+);
 
 /**
  * Parse ICO and return some images.
  *
  * @param buffer - ICO file data.
  * @param mime - MIME type for output.
- * @returns Resolves to an array of {@link ParsedImage}.
+ * @returns Resolves to an array of {@link DecodeImage}.
+ * @deprecated Use {@link decodeIco} instead.
  */
-// eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const parseICO = async (buffer: ArrayBuffer | Buffer, mime = 'image/png'): Promise<Array<ParsedImage>> => await parse(buffer, mime, Image);
+const parseICO = deprecate(
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  async (buffer: ArrayBuffer | Buffer, mime = 'image/png'): Promise<Array<DecodeImage>> => await decode(buffer, mime, Image),
+  'parseICO is deprecated. Use decodeIco instead.'
+);
 
 const ICO = {
+  decodeIco,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   isICO,
+  isIco,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   parseICO
 };
 
-export type { ParsedImage };
+export type { DecodeImage };
 
-export { isICO, parseICO };
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export { decodeIco, isICO, isIco, parseICO };
 
 export default ICO;

--- a/src/node/is-cur.test.ts
+++ b/src/node/is-cur.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { isCUR } from '../is-cur.js';
+import { isCur } from '../is-cur.js';
 import { readFile } from 'node:fs/promises';
 
-describe('isCUR', () => {
+describe('isCur', () => {
   it('is expected to return true or false', async () => {
     const buffer = await readFile(new URL('../test-fixtures/images/cursor.cur', import.meta.url));
     // @ts-expect-error test
-    expect(() => isCUR('it is not buffer')).toThrow(TypeError);
-    expect(isCUR(buffer)).toStrictEqual(true);
+    expect(() => isCur('it is not buffer')).toThrow(TypeError);
+    expect(isCur(buffer)).toStrictEqual(true);
     const d = new ArrayBuffer(4);
     const dv = new DataView(d);
-    expect(isCUR(d)).toStrictEqual(false);
+    expect(isCur(d)).toStrictEqual(false);
     dv.setUint16(2, 2, true);
-    expect(isCUR(d)).toStrictEqual(true);
+    expect(isCur(d)).toStrictEqual(true);
     dv.setUint16(0, 1, true);
-    expect(isCUR(d)).toStrictEqual(false);
+    expect(isCur(d)).toStrictEqual(false);
   });
 });

--- a/src/node/is-ico.test.ts
+++ b/src/node/is-ico.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { isICO } from '../is-ico.js';
+import { isIco } from '../is-ico.js';
 import { readFile } from 'node:fs/promises';
 
-describe('isICO', () => {
+describe('isIco', () => {
   it('is expected to return true or false', async () => {
     const buffer = await readFile(new URL('../test-fixtures/images/basic.ico', import.meta.url));
     // @ts-expect-error test
-    expect(() => isICO('it is not ArrayBuffer')).toThrow(TypeError);
-    expect(isICO(buffer)).toStrictEqual(true);
+    expect(() => isIco('it is not ArrayBuffer')).toThrow(TypeError);
+    expect(isIco(buffer)).toStrictEqual(true);
   });
 });

--- a/src/node/is-png.test.ts
+++ b/src/node/is-png.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { isPNG } from '../is-png.js';
+import { isPng } from '../is-png.js';
 import { readFile } from 'node:fs/promises';
 
-describe('isPNG', () => {
+describe('isPng', () => {
   it('is expected to return true or false', async () => {
     const buffer1 = await readFile(new URL('../test-fixtures/images/1x1/1x1-1bit.png', import.meta.url));
     const buffer2 = await readFile(new URL('../test-fixtures/images/png/256x256-32bit.png', import.meta.url));
     // @ts-expect-error test
-    expect(() => isPNG('it is not buffer')).toThrow(TypeError);
-    expect(isPNG(new ArrayBuffer(16))).toStrictEqual(false);
-    expect(isPNG(buffer1)).toStrictEqual(true);
-    expect(isPNG(buffer2)).toStrictEqual(true);
+    expect(() => isPng('it is not buffer')).toThrow(TypeError);
+    expect(isPng(new ArrayBuffer(16))).toStrictEqual(false);
+    expect(isPng(buffer1)).toStrictEqual(true);
+    expect(isPng(buffer2)).toStrictEqual(true);
   });
 });


### PR DESCRIPTION
Change function names to use camelCase.
- rename from `parseICO` to `decodeIco`
- rename from `isICO` to `isIco`